### PR TITLE
Support Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ Makefile
 *.bundle
 *.log
 pkg
+.vagrant
 

--- a/README
+++ b/README
@@ -53,3 +53,24 @@ Ruby binding:
 If you just want to use the C API, download the .tar.gz from:
 
 http://rubyforge.org/frs/?group_id=7925
+
+DEVLOPMENT
+==========
+
+Install [vagrant](https://www.vagrantup.com/).
+
+```
+$ vagrant up
+```
+
+Installs a VM with all the pieces needed for development
+
+```
+$ vagrant ssh
+$ cd /vagrant
+$ rake santity_test
+```
+
+Runs the sanity test on the vagrant box now.
+
+

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ task :changelog do
   }
 end
 
+desc "Run the tests"
 task :sanity_test do
   sh "./src/tests/sanity-test"
 end
@@ -65,7 +66,7 @@ begin
   require 'rake'
   require 'rake/clean'
   require 'rake/packagetask'
-  require 'rake/gempackagetask'
+  require 'rubygems/package_task'
   require 'fileutils'
 rescue LoadError
 else
@@ -98,10 +99,10 @@ alternative to GDBM and Berkeley DB.
     s.rubyforge_project = 'localmemcache'
   end
 
-  Rake::GemPackageTask.new(spec) do |p|
-    p.gem_spec = spec
-    p.need_tar = false
+  Rake::PackageTask.new(spec.name, spec.version.to_s) do |p|
+    p.package_files = spec.files
     p.need_zip = false
+    p.need_tar = false
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise32"
+
+  config.vm.provision 'shell', :inline => <<-SCRIPT, :privileged => false
+    set -e
+    set -x
+    # apt-get stuff, all together to perform only one "update".
+    PACKAGES="curl git build-essential"
+    dpkg -s $PACKAGES >/dev/null || {
+      sudo apt-get -y update
+      sudo apt-get -y install $PACKAGES
+    }
+    set +x # rvm vomits a ton of output with set -x, so we silence it.
+    command -v rvm >/dev/null || {
+      gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+      curl -sSL https://get.rvm.io | bash -s stable
+    }
+    . ~/.bashrc
+    . ~/.profile
+    rvm --default use 1.9.3 >/dev/null || {
+      rvm install 1.9.3
+      rvm --default use 1.9.3
+    };
+    set -x
+    command -v bundle >/dev/null || {
+      gem install bundler
+    }
+    command -v rake >/dev/null || {
+      gem install rake
+    }
+  SCRIPT
+end

--- a/src/lmc_shm.c
+++ b/src/lmc_shm.c
@@ -40,7 +40,7 @@ void lmc_shm_ensure_root_path() {
 }
 
 void lmc_file_path_for_namespace(char *result, const char *ns) {
-  if (lmc_is_filename(ns)) { snprintf(result, 1023, "%s", ns); } 
+  if (lmc_is_filename(ns)) { snprintf(result, 1023, "%s", ns); }
   else { snprintf(result, 1023, "%s/%s.lmc", lmc_namespace_root_path(), ns); }
 }
 
@@ -62,7 +62,7 @@ int lmc_clean_namespace(const char *ns, lmc_error_t *e) {
   char fn[1024];
   lmc_file_path_for_namespace((char *)&fn, ns);
   if (lmc_does_namespace_exist(ns)) {
-    if (!lmc_handle_error(unlink(fn) == -1,  "unlink", "ShmError", 
+    if (!lmc_handle_error(unlink(fn) == -1,  "unlink", "ShmError",
         fn, e)) { return 0; }
   }
   return 1;
@@ -77,9 +77,9 @@ void lmc_shm_ensure_namespace_file(const char *ns) {
 
 lmc_shm_t *lmc_shm_create(const char* namespace, size_t size, lmc_error_t *e) {
   lmc_shm_t *mc = calloc(1, sizeof(lmc_shm_t));
-  if (!mc) { 
+  if (!mc) {
     STD_OUT_OF_MEMORY_ERROR("lmc_shm_create");
-    return NULL; 
+    return NULL;
   }
   snprintf((char *)&mc->namespace, 1023, "%s", namespace);
   mc->size = size;
@@ -87,15 +87,15 @@ lmc_shm_t *lmc_shm_create(const char* namespace, size_t size, lmc_error_t *e) {
   lmc_shm_ensure_namespace_file(mc->namespace);
   char fn[1024];
   lmc_file_path_for_namespace((char *)&fn, mc->namespace);
-  if (!lmc_handle_error((mc->fd = open(fn, O_RDWR, (mode_t)0777)) == -1, 
+  if (!lmc_handle_error((mc->fd = open(fn, O_RDWR, (mode_t)0777)) == -1,
       "open", "ShmError", fn, e)) goto open_failed;
-  if (!lmc_handle_error(lseek(mc->fd, mc->size - 1, SEEK_SET) == -1, 
+  if (!lmc_handle_error(lseek(mc->fd, mc->size - 1, SEEK_SET) == -1,
       "lseek", "ShmError", fn, e)) goto failed;
-  if (!lmc_handle_error(write(mc->fd, "", 1) != 1, "write", 
+  if (!lmc_handle_error(write(mc->fd, "", 1) != 1, "write",
       "ShmError", fn, e)) goto failed;
-  mc->base = mmap(0, mc->size, PROT_READ | PROT_WRITE, MAP_SHARED, mc->fd, 
+  mc->base = mmap(0, mc->size, PROT_READ | PROT_WRITE, MAP_SHARED, mc->fd,
       (off_t)0);
-  if (!lmc_handle_error(mc->base == MAP_FAILED, "mmap", "ShmError", fn, e)) 
+  if (!lmc_handle_error(mc->base == MAP_FAILED, "mmap", "ShmError", fn, e))
      goto failed;
   return mc;
 
@@ -107,7 +107,7 @@ open_failed:
 }
 
 int lmc_shm_destroy(lmc_shm_t *mc, lmc_error_t *e) {
-  int r = lmc_handle_error(munmap(mc->base, mc->size) == -1, "munmap", 
+  int r = lmc_handle_error(munmap(mc->base, mc->size) == -1, "munmap",
       "ShmError", 0, e);
   close(mc->fd);
   free(mc);

--- a/src/tests/bacon.rb
+++ b/src/tests/bacon.rb
@@ -20,7 +20,7 @@ module Bacon
   RestrictContext = //  unless defined? RestrictContext
 
   def self.summary_on_exit
-    return  if Counter[:installed_summary] > 0
+    return if Counter[:installed_summary] > 0
     at_exit {
       handle_summary
       if $!
@@ -28,6 +28,8 @@ module Bacon
       elsif Counter[:errors] + Counter[:failed] > 0
         exit 1
       end
+
+      exit 0
     }
     Counter[:installed_summary] += 1
   end

--- a/src/tests/lmc
+++ b/src/tests/lmc
@@ -6,6 +6,9 @@ script=$DIR/lmc.rb
 if test "x$1" = "x-d"; then
   irb -r $script
 else
-  #valgrind --leak-check=full --tool=memcheck ruby $script
-  ruby $script
+  if test "x$DEBUG" = "x1"; then
+    gdb -ex run --args ruby $script
+  else
+    ruby $script
+  fi
 fi

--- a/src/tests/lmc.rb
+++ b/src/tests/lmc.rb
@@ -121,13 +121,13 @@ describe 'LocalMemCache' do
   end
 
   it 'should support filename parameters' do
-    LocalMemCache.drop :filename => ".tmp.a.lmc", :force => true
-    lm = LocalMemCache.new :filename => ".tmp.a.lmc", :size_mb => 1
+    LocalMemCache.drop :filename => "/tmp/.tmp.a.lmc", :force => true
+    lm = LocalMemCache.new :filename => "/tmp/.tmp.a.lmc", :size_mb => 1
     lm[:boo] = 1
     lm.size.should.equal 1
     File.exists?(".tmp.a.lmc").should.be.true
-    LocalMemCache.check :filename => ".tmp.a.lmc"
-    LocalMemCache.drop :filename => ".tmp.a.lmc"
+    LocalMemCache.check :filename => "/tmp/.tmp.a.lmc"
+    LocalMemCache.drop :filename => "/tmp/.tmp.a.lmc"
   end
 
 end


### PR DESCRIPTION
Make it easier to get started by allowing to just run `vagrant up` which
sets up a ubuntu VM with all the pieces installed to run `rake
sanity_test` to run the tests.
